### PR TITLE
Correction of path related to modular inputs state (modinputs)

### DIFF
--- a/splunkconf-backup/bin/splunkconf-backup.sh
+++ b/splunkconf-backup/bin/splunkconf-backup.sh
@@ -206,12 +206,12 @@ fi
 
 # fixme : move this after so that splunk_home changes apply
 # state files and dir
-#MODINPUTPATH="${SPLUNK_DB}/modinput"
+#MODINPUTPATH="${SPLUNK_DB}/modinputs"
 #SCHEDULERSTATEPATH="${SPLUNK_HOME}/var/run/splunk/scheduler"
 if [ "${TARMODE}" = "abs" ]; then
-    STATELIST="${SPLUNK_DB}/modinput ${SPLUNK_HOME}/var/run/splunk/scheduler ${SPLUNK_HOME}/var/run/splunk/cluster/remote-bundle ${SPLUNK_DB}/persistentstorage ${SPLUNK_DB}/fishbucket ${SPLUNK_HOME}/var/run/splunk/deploy"
+    STATELIST="${SPLUNK_DB}/modinputs ${SPLUNK_HOME}/var/run/splunk/scheduler ${SPLUNK_HOME}/var/run/splunk/cluster/remote-bundle ${SPLUNK_DB}/persistentstorage ${SPLUNK_DB}/fishbucket ${SPLUNK_HOME}/var/run/splunk/deploy"
 else
-    STATELIST="${SPLUNK_DB_REL}/modinput ./var/run/splunk/scheduler ./var/run/splunk/cluster/remote-bundle ${SPLUNK_DB_REL}/persistentstorage ${SPLUNK_DB_REL}/fishbucket ./var/run/splunk/deploy"
+    STATELIST="${SPLUNK_DB_REL}/modinputs ./var/run/splunk/scheduler ./var/run/splunk/cluster/remote-bundle ${SPLUNK_DB_REL}/persistentstorage ${SPLUNK_DB_REL}/fishbucket ./var/run/splunk/deploy"
 fi
 
 # configuration for scripts backups


### PR DESCRIPTION
I tested the app and the path for modular inputs state inside splunk/var/lib/splunk is modinputs, not modinput.
Please check if this should be updated elsewhere in the code other than the backup script.