### PR TITLE
Fix typos, misspellings, and a mismatched quote

### DIFF
--- a/helpers/getmycredentials.sh
+++ b/helpers/getmycredentials.sh
@@ -47,7 +47,7 @@ KEY=$3
 FI="mykey-${REGION}.priv"
 
 if [ -e "$FI" ]; then
-  echo "$FI already exist , wont attempt to overwrite it !!!! Please remove with care if you really want to update"
+  echo "$FI already exists , wont attempt to overwrite it !!!! Please remove with care if you really want to update"
   echo " result would have been :"
   aws secretsmanager  get-secret-value --secret-id $KEY --query "SecretString" --output text --region $REGION
   echo "SSM"

--- a/helpers/tftopology.sh
+++ b/helpers/tftopology.sh
@@ -81,7 +81,7 @@ for i in instance-*.tf; do
   echo "i=$i   ."
   t=instances-template/${i}
   if [ -e $t ]; then 
-    echo "ERROR $t already exist, unable to move file $i, that is unexpected, both files should not be present at same time"
+    echo "ERROR $t already exists, unable to move file $i, that is unexpected, both files should not be present at same time"
     status=1
     #exit 1
   else
@@ -113,7 +113,7 @@ if [[ $MODE -eq "2" ]]; then
     t=instances-template/$i
     if [ -e "$t" ]; then
       if [ -e "$i" ]; then
-        echo "ERROR $i already exist, unable to move file $t, that is unexpected, both files should not be present at same time"
+        echo "ERROR $i already exists, unable to move file $t, that is unexpected, both files should not be present at same time"
         status=1
         #exit 1
       else
@@ -149,7 +149,7 @@ elif [[ $MODE -eq "1" ]]; then
     t=instances-template/$i
     if [ -e "$t" ]; then
       if [ -e "$i" ]; then
-        echo "ERROR $i already exist, unable to move file $t, that is unexpected, both files should not be present at same time"
+        echo "ERROR $i already exists, unable to move file $t, that is unexpected, both files should not be present at same time"
         status=1
         #exit 1
       else

--- a/splunkconf-backup/bin/splunkconf-backup.sh
+++ b/splunkconf-backup/bin/splunkconf-backup.sh
@@ -57,7 +57,7 @@ exec > /tmp/splunkconf-backup-debug.log  2>&1
 # 20191018 correct exit codes to have ES checks happy, change version test to less depend on external command, change manageport detection that dont work on all env, reduce tar kvstore loop try as we have kvdump
 # 20200304 add logic for more generic /etc/instance-tags for non aws case + more logging improvements and move lots of logging to debug levea, fix statelist var in log message
 # 20200309 disable old tar kvstore when doing kvdump, more logging improvements
-# 20200314 add restore lock check to avoid launching a backup while a restore is still running (big kvdump for example) (may be theorically possible but add load to kvstore and not really make sense) 
+# 20200314 add restore lock check to avoid launching a backup while a restore is still running (big kvdump for example) (may be theoretically possible but add load to kvstore and not really make sense) 
 # 20200318 add ability to pass parameter for specific backup only in order to do more fine grained scheduling
 # 20200502 change disk space check to not exit immediately in order to report more info for backup that are missing (to be used for reporting logic)
 # 20200502 make code more modular, improve logging for full etc case, add disabled apps dir to targeted etc, set umask explicitely, change check for kvstore remote copy  
@@ -154,7 +154,7 @@ exec > /tmp/splunkconf-backup-debug.log  2>&1
 # 20251216 more curl timeout
 # 20251217 propage script autodisable status so remote copy status is always aligned
 # 20251218 improve remote copy and disabled modes to prevent useless retries which add unecessary logging
-# 20251219 propagate error from local to remote to avoid logging disabled when it is a failure du to local (like disk space issue)
+# 20251219 propagate error from local to remote to avoid logging disabled when it is a failure due to local (like disk space issue)
 # 20260105 update time logging format
 # 20260324 add more debug logging for remotebackup
 # 20260324 update condition fro unconfigured s3
@@ -185,7 +185,7 @@ SPLUNK_HOME=`cd ../../..;pwd`
 # debug -> verify the env that splunk set (python version may affect aws command for example,...)
 #env
 # unsetting env to not depend on splunk python version 
-# this is because we may call aws command which is in python itself and can break du to this
+# this is because we may call aws command which is in python itself and can break due to this
 unset LD_LIBRARY_PATH
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
 unset PYTHONHASHSEED
@@ -205,7 +205,7 @@ CURLMAXTIME=60
 
 # we always do relative backup but if ever you want the old way, change mode below to abs
 # recovery part support both mode 
-# du to recent tar behavior related to exclusion it is better to use rel mode
+# due to recent tar behavior related to exclusion it is better to use rel mode
 TARMODE="rel"
 # this is the form that gets added in name if the backup was made relative to splunk home
 # otherwise no extension
@@ -422,7 +422,7 @@ function splunkconf_purgebackup {
 function splunkconf_checkspace { 
   CURRENTAVAIL=`df --output=avail -k  ${LOCALBACKUPDIR} | tail -1`
   if [[ ${MINFREESPACE} -gt ${CURRENTAVAIL} ]]; then
-    # we dont report the error here in normal case as it will be reported with nore info by the local backup functions
+    # we dont report the error here in normal case as it will be reported with more info by the local backup functions
     debug_log "action=checkdiskfree mode=$MODE, minfreespace=${MINFREESPACE}, currentavailable=${CURRENTAVAIL} type=localdiskspacecheck reason=insufficientspaceleft result=fail ERROR : Insufficient disk space left , disabling backups ! Please fix "
     ERROR=1
     ERROR_MESS="localdiskspacecheck"
@@ -459,7 +459,7 @@ function check_cloud() {
       cloud_type=1
     fi
   fi
-  # if detection not yet successfull, try fallback method
+  # if detection not yet successful, try fallback method
   if [[ $cloud_type -eq "0" ]]; then
     # Fallback check of http://169.254.169.254/. If we wanted to be REALLY
     # authoritative, we could follow Amazon's suggestions for cryptographically
@@ -710,7 +710,7 @@ function do_remote_copy() {
         break
       else
         # not nornal, we still log a failure even if not the last attempt
-        # note this can fail du to timeout if qos or lack of ressources on s3 or server
+        # note this can fail due to timeout if qos or lack of ressources on s3 or server
         fail_log "action=backup type=${TYPE} object=${OBJECT} result=failure src=${LFIC} dest=${RFIC} durationms=${DURATION} size=${FILESIZE} err=$RES  ATTEMPT=$ATTEMPT MAXTRY=$REMOTECOPYRETRY"
       fi
     fi
@@ -1396,7 +1396,7 @@ if [ ! -d "$LOCALBACKUPDIR" ]; then
     exit 1;
   fi
 else
-  debug_log "OK: backup dir $LOCALBACKUPDIR already exist"
+  debug_log "OK: backup dir $LOCALBACKUPDIR already exists"
 fi
 
 if [ ! -w $LOCALBACKUPDIR ] ; then 

--- a/splunkconf-backup/bin/splunkconf-checkbackup.sh
+++ b/splunkconf-backup/bin/splunkconf-checkbackup.sh
@@ -39,7 +39,7 @@ SPLUNK_HOME=`cd ../../..;pwd`
 # debug -> verify the env that splunk set (python version may affect aws command for example,...)
 #env
 # undetting env to not depend on splunk python version
-# this is because we may call aws command which is in python itself and can break du to this
+# this is because we may call aws command which is in python itself and can break due to this
 unset LD_LIBRARY_PATH
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
 unset PYTHONHASHSEED
@@ -55,7 +55,7 @@ CURLMAXTIME=60
 
 ##### LOCAL
 
-# Used for checking that backup is more recent than this value, dont forget to add a margin related to backup frequency as the backup time may change slightly even if theorically running at same time
+# Used for checking that backup is more recent than this value, dont forget to add a margin related to backup frequency as the backup time may change slightly even if theoretically running at same time
 BACKUPRECENCY=86500
 
 LOCALBACKUPDIR="${SPLUNK_HOME}/var/backups"

--- a/splunkconf-backup/bin/splunkconf-purgebackup.sh
+++ b/splunkconf-backup/bin/splunkconf-purgebackup.sh
@@ -48,7 +48,7 @@ exec > /tmp/splunkconf-purgebackup-debug.log  2>&1
 # 20200421 improve logging
 # 20201105 add test for default and local conf file to prevent error appearing in logs
 # 20220326 add support for rel and zstd types by relaxing form detection
-# 20220326 change starving condition to fail even if that is probably du to external condition in order to try to be more visible that we have a problem + only log when all the types have been tried 
+# 20220326 change starving condition to fail even if that is probably due to external condition in order to try to be more visible that we have a problem + only log when all the types have been tried 
 # 20220327 improve logging by adding freespace info
 # 20230704 add rcp purge support
 # 20230913 add more debug log for system local conf file
@@ -186,7 +186,7 @@ function fail_log {
 function splunkconf_checkspace {
   CURRENTAVAIL=`df --output=avail -k  ${LOCALBACKUPDIR} | tail -1`
   if [[ ${MINFREESPACE} -gt ${CURRENTAVAIL} ]]; then
-    # we dont report the error here in normal case as it will be reported with nore info by the local backup functions
+    # we dont report the error here in normal case as it will be reported with more info by the local backup functions
     debug_log "mode=$MODE, minfreespace=${MINFREESPACE}, currentavailable=${CURRENTAVAIL} type=localdiskspacecheck reason=insufficientspaceleft action=checkdiskfree result=fail ERROR : Insufficient disk space left , disabling backups ! Please fix "
     ERROR=1
     ERROR_MESS="localdiskspacecheck"
@@ -238,7 +238,7 @@ function check_cloud() {
       cloud_type=1
     fi
   fi
-  # if detection not yet successfull, try fallback method
+  # if detection not yet successful, try fallback method
   if [[ $cloud_type -eq "0" ]]; then
     # Fallback check of http://169.254.169.254/. If we wanted to be REALLY
     # authoritative, we could follow Amazon's suggestions for cryptographically

--- a/splunkconf-backup/bin/splunkconf-restorebackup.sh
+++ b/splunkconf-backup/bin/splunkconf-restorebackup.sh
@@ -79,7 +79,7 @@ exec > /tmp/splunkconf-restore-debug.log  2>&1
 # 20251201 rework version detection, update with the one from backup to change the logic to be consistent (help with v10)
 # 20251202 align load settings with backup version
 # 20251215 remove version check for kvdump, assuming always version at minimum 7.1
-# 20251215 add backup dir creation to avoid error and delay du to check disk space not working correctly
+# 20251215 add backup dir creation to avoid error and delay due to check disk space not working correctly
 # 20251215 add timeout for curl command to speed up backup for on prem with firewalls
 # 20251219 add failure log for backup in disk space situation at first start in order to fill dashboard from start with correct info
 # 20260105 update time logging format
@@ -111,7 +111,7 @@ SPLUNK_HOME=`cd ../../..;pwd`
 # debug -> verify the env that splunk set (python version may affect aws command for example,...)
 #env
 # unsetting env to not depend on splunk python version 
-# this is because we may call aws command which is in python itself and can break du to this
+# this is because we may call aws command which is in python itself and can break due to this
 unset LD_LIBRARY_PATH
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
 unset PYTHONHASHSEED
@@ -397,7 +397,7 @@ if [ ! -d "$LOCALBACKUPDIR" ]; then
     exit 1;
   fi
 else
-  debug_log "OK: backup dir $LOCALBACKUPDIR already exist"
+  debug_log "OK: backup dir $LOCALBACKUPDIR already exists"
 fi
 
 if [ ! -w $LOCALBACKUPDIR ] ; then 

--- a/src/installes.sh
+++ b/src/installes.sh
@@ -29,7 +29,7 @@
 # 20200412 add version check to autoadapt to the version and keep one single script for all versions, add prompt to continue installation and try to run all conditions even when failure to have the admin build faster the list of all things to fix, move some messages to debug log level 
 # 20200416 add sha256 for ES 6.1.1 and make it default
 # 20200508 add sha256 for ES6.2, use more relaxed regex for final check as the log sligthly changed with latest versions
-# 20200629 fix shc test for ES content update, add ESINSTALLERNFORCENOTA and remove TA options fron essinstall for 6.2. change default to 6.2
+# 20200629 fix shc test for ES content update, add ESINSTALLERNFORCENOTA and remove TA options from essinstall for 6.2. change default to 6.2
 # 20201103 add version var + fix typo in message
 # 20201123 add sha for es6.4
 # 20201215 update sha for 6.4 as the build was updated 
@@ -319,7 +319,7 @@ fi
 # folder will always contain README
 if [[ $(/usr/bin/find ${SPLUNK_HOME}/etc/shcluster/apps |wc -l) >2 ]]; then
    SHC=1
-   echo "looks like we may be running on a SHC deployer, shc install mode prefered for ES5.3+ "
+   echo "looks like we may be running on a SHC deployer, shc install mode preferred for ES5.3+ "
 else
    SHC=0
    echo "deployer not detected. Using default sh mode"

--- a/src/setcgroup.sh
+++ b/src/setcgroup.sh
@@ -19,14 +19,14 @@
 # Matthieu Araman, Splunk
 
 # This script test cgroup version and will reconfigure it in v1 compatibility mode if v2 is used
-# This need to be done only for Splunk versions not supporting cgroupv2 (as when cgroupv2 will be supported , it will allow WLM to leverage cgroupv2 only functionalities) 
-# This need a reboot to be taken into account 
+# This needs to be done only for Splunk versions not supporting cgroupv2 (as when cgroupv2 will be supported , it will allow WLM to leverage cgroupv2 only functionalities) 
+# This needs a reboot to be taken into account 
 
 # script return code
 # 0 = all good
 # 1 = need reboot
 
-# 20240316 extract cgroup logic fron splunkconf-cloud-recovery. sh in a specific script to make it easier to use outside recovery
+# 20240316 extract cgroup logic from splunkconf-cloud-recovery. sh in a specific script to make it easier to use outside recovery
 
 cgroup_status () {
   NEEDCGROUPDISABLED=0

--- a/src/setcgroupv2.sh
+++ b/src/setcgroupv2.sh
@@ -19,14 +19,14 @@
 # Matthieu Araman, Splunk
 
 # This script test cgroup version and will reconfigure it in v1 compatibility mode if v2 is used
-# This need to be done only for Splunk versions not supporting cgroupv2 (as when cgroupv2 will be supported , it will allow WLM to leverage cgroupv2 only functionalities) 
-# This need a reboot to be taken into account 
+# This needs to be done only for Splunk versions not supporting cgroupv2 (as when cgroupv2 will be supported , it will allow WLM to leverage cgroupv2 only functionalities) 
+# This needs a reboot to be taken into account 
 
 # script return code
 # 0 = all good
 # 1 = need reboot
 
-# 20240316 extract cgroup logic fron splunkconf-cloud-recovery. sh in a specific script to make it easier to use outside recovery
+# 20240316 extract cgroup logic from splunkconf-cloud-recovery. sh in a specific script to make it easier to use outside recovery
 # 20240805 version to force cgroup to v2 when possible
 
 cgroup_status () {

--- a/src/splunkconf-cloud-recovery.sh
+++ b/src/splunkconf-cloud-recovery.sh
@@ -119,7 +119,7 @@ exec >> /var/log/splunkconf-cloud-recovery-debug.log 2>&1
 # 20210627 add splunkconnectedmode tag + initial detection logic
 # 20210627 add splunkosupdatemode tag
 # 20210627 add rpm for 8.2.1 (no change to default)
-# 20210707 fix regression in splunkconf-backup du to splunkbase packaging change
+# 20210707 fix regression in splunkconf-backup due to splunkbase packaging change
 # 20210707 add splunkcloudmode support to ease deploying collection layer to splunkcloud or test instance that index to splunkcloud
 # 20210719 up default to 8.1.5 
 # 20210902 add splunkinstancesnb tag support (multids only)
@@ -318,7 +318,7 @@ function check_cloud() {
       cloud_type=1
     fi
   fi
-  # if detection not yet successfull, try fallback method
+  # if detection not yet successful, try fallback method
   if [[ $cloud_type -eq "0" ]]; then 
     # Fallback check of http://169.254.169.254/. If we wanted to be REALLY
     # authoritative, we could follow Amazon's suggestions for cryptographically
@@ -491,7 +491,7 @@ setup_disk () {
     MKOPTIONS=" -m 0 -T largefile4 -E lazy_itable_init"
     # for ephemeral , we can add sparse_super with no drawback"
     #MKOPTIONSEPHEMERAL="-O sparse_super -m 0 -T largefile4 -E lazy_itable_init"
-    # largefile4 may create too few inodes , check with df -i  ,switching to huge which create nore inodes
+    # largefile4 may create too few inodes , check with df -i  ,switching to huge which create more inodes
     MKOPTIONSEPHEMERAL="-O sparse_super -m 0 -T huge -E lazy_itable_init"
     if [[ "$splunkenableunifiedpartition" == "true" ]]; then
       echo "Using unified partition mode"
@@ -1450,7 +1450,7 @@ else
   sizeuser=${#splunkuser} 
   sizemin=5
   if (( sizeuser < sizemin )); then
-    # this may be the case on GCP du to thwe way we get tag, the var exist but is empty like
+    # this may be the case on GCP due to the way we get tag, the var exist but is empty like
     echo "splunk user length too short or empty tag, bad input or extra characters, ignoring tag value and assuming user is splunk"
     usersplunk="splunk"
     splunkuser="splunk"
@@ -1763,7 +1763,7 @@ else
         echo "ERROR : GPG Check failed after multiple tries, splunk rpm file may be corrupted, please check and relaunch\n"
         exit 1
       else
-        echo "ERROR : GPG Check failed, may be temporary du to rpm lock, will retry (COUNT=$COUNT)"
+        echo "ERROR : GPG Check failed, may be temporary due to rpm lock, will retry (COUNT=$COUNT)"
         sleep 5
         # retry import key just in case this is the issue
         rpm --import /root/splunk-gpg-key.pub
@@ -2179,7 +2179,7 @@ if [ "$MODE" != "upgrade" ]; then
     site="site${sitenum}"
     echo "Indexer detected setting site for availability zone $AZONE (letter=$ZONELETTER,sitenum=$sitenum, site=$site) " >> /var/log/splunkconf-cloud-recovery-info.log
     # removing any conflicting app that could define site
-    # giving back files to splunk user (this is required here as if the permissions are incorrect from tar file du to packaging issues, the delete from splunk below will fail here)
+    # giving back files to splunk user (this is required here as if the permissions are incorrect from tar file due to packaging issues, the delete from splunk below will fail here)
     chown -R ${usersplunk}. $SPLUNK_HOME
     FORME="*site*base"
     # find app that match forn and deleting the app folder
@@ -2449,7 +2449,7 @@ else
         echo "ERROR : rpm fail after multiple tries, please investigate and relaunch, exiting\n"
         exit 1
       else
-        echo "ERROR : rpm command failed, may be temporary du to rpm lock, will retry (COUNT=$COUNT)"
+        echo "ERROR : rpm command failed, may be temporary due to rpm lock, will retry (COUNT=$COUNT)"
         sleep 5 
       fi
     fi
@@ -2481,7 +2481,7 @@ if ! [[ "${instancename}" =~ ^(auto|indexer|idx|idx1|idx2|idx3|uf|ix-site1|ix-si
     else
      echo "no previous splunkconf-backup app deployed, no need to clean up before deploying app"
     fi
-    # Note : old versions used relative path, new version without du to splunkbase packaging requirement
+    # Note : old versions used relative path, new version without due to splunkbase packaging requirement
     tar -C "${SPLUNK_HOME}/etc/apps" -xzf ${localinstalldir}/splunkconf-backup.tar.gz 
     # removing old version for upgrade case 
     if [ -e "/etc/crond.d/splunkbackup.cron" ]; then
@@ -2642,7 +2642,7 @@ if [ "$MODE" != "upgrade" ]; then
   # this is restored by backup scripts (initial one) but only present if the admin decided it is necessary (ie for example to update dns for some instances)
   # if needed this is calling other scripts
   if [ -e ${localrootscriptdir}/aws-postinstall.sh ]; then
-    echo "lauching aws-postinstall in ${localrootscriptdir}/aws-postinstall.sh" >> /var/log/splunkconf-cloud-recovery-info.log
+    echo "launching aws-postinstall in ${localrootscriptdir}/aws-postinstall.sh" >> /var/log/splunkconf-cloud-recovery-info.log
     chown root. ${localrootscriptdir}/aws-postinstall.sh
     chmod u+x ${localrootscriptdir}/aws-postinstall.sh
     ${localrootscriptdir}/aws-postinstall.sh
@@ -2717,7 +2717,7 @@ fi
 if [ $splunkconnectedmode == 1 ]; then
   pip install boto3
 else 
-  echo "INFO: boto3 deployment via pip disabled du to splunkconnectedmode=$splunkconnectedmode"
+  echo "INFO: boto3 deployment via pip disabled due to splunkconnectedmode=$splunkconnectedmode"
 fi
 # only on worker
 if [[ $splunkenableworker == 1 ]]; then
@@ -2779,7 +2779,7 @@ if [[ $splunkenableworker == 1 ]]; then
   if [ $splunkconnectedmode == 1 ]; then
     pip install ansible
   else 
-    echo "not deploying ansible du to splunkconnectedmode setting ($splunkconnectedmode), make sure you have deployed it yourself or change setting"
+    echo "not deploying ansible due to splunkconnectedmode setting ($splunkconnectedmode), make sure you have deployed it yourself or change setting"
   fi
   echo "building inventory file with ansible"
   su - ${usersplunk} -c "cd scripts/splunk-ansible-develop;ansible-playbook splunk_ansible_inventory_create.yml -i 127.0.0.1," 
@@ -2793,7 +2793,7 @@ if [[ $splunkenableworker == 1 ]]; then
   #su - ${usersplunk} -c "cd actions-runner;./config.sh --url https://${apprepo} --token ${patrunner} ;nohup ./run.sh &"
 fi
 
-# redo tag replacement as btool may not work before splunkconf-init du to splunk not yet initialized 
+# redo tag replacement as btool may not work before splunkconf-init due to splunk not yet initialized 
 tag_replacement
 
 if [ -z ${splunkpostextrasyncdir+x} ]; then 

--- a/src/splunkconf-ds-reload.sh
+++ b/src/splunkconf-ds-reload.sh
@@ -128,7 +128,7 @@ until [[ "$LOGGEDIN" -eq "1" ]] ; do
      #PORT=`head -1 ${MGTPORT}`
      #SPLUNK_URI="https://127.0.0.1:${PORT}"
      #echo "SPLUNK_URI=${SPLUNK_URI}."
-     # note as we changed commandi path, it will figure outthe port itself
+     # note as we changed command path, it will figure out the port itself
      # we only test with first instance as the password are supposed to be the same on all the instances
      SPLUNK_HOME="${SPLUNK_HOME_ORIG}/splunk_ds1"
      SPLUNK_BIN="${SPLUNK_HOME}/bin/splunk"
@@ -152,7 +152,7 @@ echo_log "OK, logged in"
 
 if [[ -e "${SPLUNKCONF_BACKUP_BIN}" ]]; then 
   if [[ -e "${SPLUNKCONF_PURGEBACKUP_BIN}" ]]; then
-    echo_log "purging old backups to freee up space for new backups"
+    echo_log "purging old backups to free up space for new backups"
     `cd ${SPLUNK_APPS};${SPLUNKCONF_PURGEBACKUP_BIN}`
   else 
     fail_log "ERROR ! Missing ${SPLUNKCONF_PURGEBACKUP_BIN}"
@@ -186,7 +186,7 @@ do
    SPLUNK_BIN="${SPLUNK_HOME}/bin/splunk"
    if [[ -e "${SPLUNK_BIN}" ]]; then
      echo_log "Reloading DS for instance $i, path=${SPLUNK_HOME}"
-     # we need to login just before because du to the time it take we could be in the situation where the token expire !
+     # we need to login just before because due to the time it take we could be in the situation where the token expire !
      ${SPLUNK_HOME}/bin/splunk login -auth $SPLADMIN:$SPLPASS 
      ${SPLUNK_HOME}/bin/splunk reload deploy-server $CLASSES
      echo_log "reload initiated for instance $i, sleeping 30s"

--- a/src/splunkconf-init.pl
+++ b/src/splunkconf-init.pl
@@ -432,7 +432,7 @@ if (-e "/bin/su") {
 
 # if we are installing first time, we expect that admin has created user-seed.conf
 # see https://docs.splunk.com/Documentation/Splunk/latest/Admin/User-seedconf
-# if this is not the first time, then we have a already existing passwd file
+# if this is not the first time, then we have an already existing passwd file
 # if neither are there, we won't have a admin password set !
 # for uf, that could be a good thing but for central component, we should probably ask for the admin to correct before running the installation
 
@@ -472,7 +472,7 @@ if ($splunkrole =~/ds|deployment/ ) {
     # moving to reuse default content then creating symlink
     `mv $SPLDEPLAPPSDIR $SPLDEPLAPPSDIR_ORIG;ln -s $SPLDEPLAPPSDIR_ORIG $SPLDEPLAPPSDIR`;
   }
-  # adding links fron deployment apps to etc apps on DS to increase app consistency (still need a manual restart of DS in case the config change)
+  # adding links from deployment apps to etc apps on DS to increase app consistency (still need a manual restart of DS in case the config change)
   my @etcapps= split(',',$dsetcapps);
   foreach my $val (@etcapps) {
     print "looking at etc apps for $val\n";
@@ -545,7 +545,7 @@ EOF
   # serverclass deployment app link
   # auto link for serverclass app (need to be named app_serverclass and contain local/serverclass.conf)
   if ( -e "$SPLUNK_HOME_ORIG/etc/deployment-apps/app_serverclass/local/serverclass.conf" ) {
-    print "app app_serverclass already exist\n";
+    print "app app_serverclass already exists\n";
   } else {
     print "creating app_serverclass,  make sure to sync it in git repo if git used\n";
     `mkdir -p $SPLUNK_HOME_ORIG/etc/deployment-apps/app_serverclass/local`;
@@ -616,7 +616,7 @@ if (-d $INITIALSPLAPPSDIR) {
 
 # if splunkforwarder then it is normal to not create a admin account to reduce attack surface
 if (-e $SPLPASSWDFILE) {
-  print "OK: splunk pwd file exist (from backup or because upgrade)-> Existing passord, all good, no need to fetch user seed or generate one\n";
+  print "OK: splunk pwd file exist (from backup or because upgrade)-> Existing password, all good, no need to fetch user seed or generate one\n";
 } elsif (-e $SPLUSERSEED) {
   print "OK: no existing password yet but splunk user seed file provided, will use this user seed file\n";
 } elsif (($SPLUNK_SUBSYS eq "splunkforwarder") || ($splunkrole =~/uf/ )) {
@@ -810,7 +810,7 @@ if ($USESPLINDEX) {
        `/bin/chown -R $USERSPLUNK. $SPLUNK_INDEXES`;
 }
 
-# give file back to splunk just in case  (see also releases notes SPL-89640, this is required during upgrade du to a rpm ressetting a dir as root))
+# give file back to splunk just in case  (see also releases notes SPL-89640, this is required during upgrade due to a rpm resetting a dir as root))
 
 #  chown sometimes fail and return non 0 code making the script die
 # if you are sure that it works, uncomment the die part (add a ; at the end)
@@ -923,7 +923,7 @@ SERVICENAME=\${COMM[2]}
 
 /bin/logger -p authpriv.info  "polkit_splunk called pid=\$1. systemctlaction=\$ACTION, servicename=\$SERVICENAME"
 
-# status action is not usually needed, it should be already autorized
+# status action is not usually needed, it should be already authorized
 if [[ "\$ACTION" == "start" ]] || 
    [[ "\$ACTION" == "stop"  ]] || 
    [[ "\$ACTION" == "status"  ]] || 

--- a/src/splunkconf-multids-setup-classic.sh
+++ b/src/splunkconf-multids-setup-classic.sh
@@ -46,7 +46,7 @@ splunkdsnb=4
 splunkorg="org"
 # replace with the version you deploy
 splbinary="splunkxxxxxx.tar.gz"
-SPLUNK_HOME="/opt/splunk'
+SPLUNK_HOME="/opt/splunk"
 localinstalldir="${SPLUNK_HOME}/var/install"
 # you can change here (for example to use a custom user and group) but make sure you are still in systemd as the multids rely on it
 SPLUNKINITOPTIONS=""

--- a/src/splunkconf-prepare-es-from-s3.sh
+++ b/src/splunkconf-prepare-es-from-s3.sh
@@ -118,7 +118,7 @@ aws s3 cp $remoteappsdir/$ESAPP  $localappsinstalldir --quiet
 if [ -e "$localappsinstalldir/$ESAPP" ]; then
   echo "OK: ES install file $ESAPP present at $remoteappsdir and downloaded to $localappsinstalldir for installes.sh later use"
 else
-  echo "KO: ES install file $ESAPP is NOT present in s3 install at $remoteappsdir: Please upload correct ES app version to s3 install or update this script is you want to use a different version"
+  echo "KO: ES install file $ESAPP is NOT present in s3 install at $remoteappsdir: Please upload correct ES app version to s3 install or update this script if you want to use a different version"
   ((FAIL++))
 fi
 

--- a/src/splunkconf-swapme.pl
+++ b/src/splunkconf-swapme.pl
@@ -6,7 +6,7 @@
 # - allow the os to move unused thing to swap
 # - give flexibility to the os memory management to avoid killing processes too early , especially when there are temporary burs
 # System should not be swapping permanently of course, use Splunk monitoring Console or OS tools to monitor usaget 
-# This should be part of global strategy on ressource management that is multiple things working together  :
+# This should be part of global strategy on resource management that is multiple things working together  :
 # - correctly sized instance
 # - WLM
 # - user profiles
@@ -135,7 +135,7 @@ if ($AVAIL2<=0) {
 
 print "trying to create a swapfile at $PARTITIONFAST/swapfile with size $WANTED14\n";
 if (-e "$PARTITIONFAST/swapfile") {
-  print "swapfile $PARTITIONFAST/swapfile already exist , doing nothing\n";
+  print "swapfile $PARTITIONFAST/swapfile already exists , doing nothing\n";
 } else {
   my $WANTED5=1024*$WANTED14;
   print "Going to create swapfile at $PARTITIONFAST/swapfile with size $WANTED5, adding \"$PARTITIONFAST/swapfile none swap sw 0 0\" to /etc/fstab and activating with swapon -a";

--- a/src/splunkconf-upgrade-local-precheck.sh
+++ b/src/splunkconf-upgrade-local-precheck.sh
@@ -62,7 +62,7 @@ function check_cloud() {
       cloud_type=1
     fi
   fi
-  # if detection not yet successfull, try fallback method
+  # if detection not yet successful, try fallback method
   if [[ $cloud_type -eq "0" ]]; then 
     # Fallback check of http://169.254.169.254/. If we wanted to be REALLY
     # authoritative, we could follow Amazon's suggestions for cryptographically

--- a/src/splunkconf-upgrade-local.sh
+++ b/src/splunkconf-upgrade-local.sh
@@ -54,6 +54,6 @@ if [ -e "$localinstalldir/splunkconf-cloud-recovery.sh" ]; then
   # need to pass upgrade argument,  for the rest we will use contextual data from tags
   . $localinstalldir/splunkconf-cloud-recovery.sh upgrade 
 else
-  echo "splunkconf-cloud-recovery.sh could not be downloaded, please check that it is on s3 install , that iam are set to autorize and tags for splunks3installbucket is set" 
+  echo "splunkconf-cloud-recovery.sh could not be downloaded, please check that it is on s3 install , that iam are set to authorize and tags for splunks3installbucket is set" 
 fi
 echo "end of splunkconf upgrade script"

--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,7 @@
 echo "************************** SSH key check "
 
 if [ ! -e "~/.ssh/id_rsa" ]; then
-  echo "no ssh key , creating one for access to basrtion host"
+  echo "no ssh key , creating one for access to bastion host"
   echo -ne '\n' | ssh-keygen -q -t rsa -f ~/.ssh/id_rsa
 else
   echo "ssh key exist"
@@ -50,7 +50,7 @@ cd splunkconf-backup
 
 # 2 options here 
 # either normal modules then use loca-preparation-withmodules.tf
-# either with remotestate (as below) so we can partially destroy without destroying bastion, ssh key declaration (AWS API is limited on this part, which doesnt help terraform knows what to do) and kms (if we want to reusae data in bucket later on)   (file local-preparation-withremotestate.tf)
+# either with remotestate (as below) so we can partially destroy without destroying bastion, ssh key declaration (AWS API is limited on this part, which doesnt help terraform knows what to do) and kms (if we want to reuse data in bucket later on)   (file local-preparation-withremotestate.tf)
 # at the moment , below logic is with remotestate which match files in git
 
 #for i in kms network ssh 

--- a/terraform/scripts/createbuckets-directories.sh
+++ b/terraform/scripts/createbuckets-directories.sh
@@ -78,7 +78,7 @@ do
   fi
 done
 # splunk.secret is a file generated first time by Splunk . If you provide one, it will be deployed which ease deploying already obfuscated config in a distributed env (it may e less necessary with v9+ that automatically handle different splunk.secret in a indexer  cluster
-# user-seed.conf contains hashed splunk admin password. it avoid to have admin passord in clear format here. If you dont provide one, installation will proceed and either you already had one from backups or yopu can always add this later
+# user-seed.conf contains hashed splunk admin password. it avoid to have admin password in clear format here. If you dont provide one, installation will proceed and either you already had one from backups or you can always add this later
 
 # same for system files
 SOURCE="system"

--- a/terraform/variables-global.tf
+++ b/terraform/variables-global.tf
@@ -5,7 +5,7 @@ variable "profile" {
 }
 
 # do not use, replaced by region-primary
-# we cant remove easily du to the way TF store things in state
+# we cant remove easily due to the way TF store things in state
 variable "region-master" {
   description = "(legacy, please use region-primary) ) primary AWS region to use (us-east-1,eu-west-3,...)"
   type        = string


### PR DESCRIPTION
## Summary

- Fix spelling errors in comments, log messages, and echo output across 20 files (shell scripts, Perl scripts, Terraform configs)
- All changes are to string literals in comments and user-facing messages -- no logic, variable, or control flow changes
- **Potential bug fix**: `SPLUNK_HOME="/opt/splunk'` had a mismatched quote (double-quote opened, single-quote closed) in `src/splunkconf-multids-setup-classic.sh` line 49. Changed to `SPLUNK_HOME="/opt/splunk"` with matching double quotes.

## Changes by category

### Misspellings (in comments and log/echo strings)
| Typo | Correction | Count |
|------|-----------|-------|
| du to | due to | 17 |
| fron | from | 4 |
| successfull | successful | 4 |
| already exist | already exists | 8 |
| passord | password | 2 |
| autorize | authorize | 2 |
| nore | more | 3 |
| theorically | theoretically | 2 |
| This need | This needs | 4 |
| ressource(s) | resource(s) | 2 |
| ressetting | resetting | 1 |
| basrtion | bastion | 1 |
| outthe | out the | 1 |
| commandi | command | 1 |
| freee | free | 1 |
| yopu | you | 1 |
| lauching | launching | 1 |
| reusae | reuse | 1 |
| thwe | the | 1 |
| prefered | preferred | 1 |
| is you want | if you want | 1 |
| a already | an already | 1 |

### Mismatched quote (potential bug)
- `src/splunkconf-multids-setup-classic.sh` line 49: `SPLUNK_HOME="/opt/splunk'` changed to `SPLUNK_HOME="/opt/splunk"`

## Files changed (20)
- `helpers/getmycredentials.sh`, `helpers/tftopology.sh`
- `splunkconf-backup/bin/splunkconf-backup.sh`, `splunkconf-checkbackup.sh`, `splunkconf-purgebackup.sh`, `splunkconf-restorebackup.sh`
- `src/installes.sh`, `src/setcgroup.sh`, `src/setcgroupv2.sh`, `src/splunkconf-cloud-recovery.sh`, `src/splunkconf-ds-reload.sh`, `src/splunkconf-init.pl`, `src/splunkconf-multids-setup-classic.sh`, `src/splunkconf-prepare-es-from-s3.sh`, `src/splunkconf-swapme.pl`, `src/splunkconf-upgrade-local-precheck.sh`, `src/splunkconf-upgrade-local.sh`
- `start.sh`
- `terraform/scripts/createbuckets-directories.sh`, `terraform/variables-global.tf`

## Test plan
- [ ] Verify no variable names or script logic was altered (all changes are in string literals)
- [ ] Grep for each original typo to confirm it no longer appears
- [ ] Confirm the mismatched quote fix in splunkconf-multids-setup-classic.sh resolves correctly